### PR TITLE
migrate to using a rayon threadpool for processing the logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -196,6 +196,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -224,6 +267,12 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
+
+[[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "encoding_rs"
@@ -628,8 +677,10 @@ dependencies = [
  "anyhow",
  "axum",
  "chrono",
+ "crossbeam-utils",
  "hyper",
  "nom",
+ "rayon",
  "sentry",
  "sentry-anyhow",
  "sentry-panic",
@@ -670,6 +721,15 @@ name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -971,6 +1031,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "rayon"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1089,6 +1171,12 @@ checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
 dependencies = [
  "windows-sys 0.42.0",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "security-framework"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,9 @@ anyhow = "1.0.69"
 axum = { version = "0.6.7", features = ["headers"] }
 chrono = { version = "0.4.23", default-features = false }
 hyper = "0.14.24"
+crossbeam-utils = "0.8.14"
 nom = "7.1.3"
+rayon = "1.6.1"
 sentry = "0.30.0"
 sentry-anyhow = { version = "0.30.0", features = ["backtrace"] }
 sentry-panic = "0.30.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use crate::server::build_app;
 use anyhow::Result;
+use crossbeam_utils::sync::WaitGroup;
 use std::{
     borrow::Cow,
     net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -21,7 +22,8 @@ mod test_utils;
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
-    let config = Arc::new(config::Config::init_from_env()?);
+    let waitgroup = WaitGroup::new();
+    let config = Arc::new(config::Config::init_from_env()?.with_waitgroup(waitgroup.clone()));
     info!(?config, "config loaded");
 
     let heroku_release = std::env::var("HEROKU_RELEASE_VERSION").ok();
@@ -68,6 +70,9 @@ async fn main() -> Result<()> {
         .serve(app.into_make_service())
         .with_graceful_shutdown(shutdown_signal())
         .await?;
+
+    info!(?waitgroup, "waiting for pending tasks");
+    waitgroup.wait();
 
     Ok(())
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -48,16 +48,16 @@ pub(crate) async fn handle_logs(
     };
 
     // move decoding, parsing and creating the logmessage
-    // into the "blocking task" threadpool of tokio.
-    // See
-    // https://docs.rs/tokio/latest/tokio/task/fn.spawn_blocking.html
-    // When the tokio runtime is shut down / dropped, it
-    // will wait until all spawned tasks are finished.
+    // into the main background rayon threadpool.
     //
-    // FIXME: since this is CPU bound, we actually should use a semaphore to
-    // limit the number of tasks, as recommended by the documentation.
-    tokio::task::spawn_blocking({
+    // By default, When the app is shut down, pending tasks
+    // would be dropped by rayon.
+    //
+    // By using a [`WaitGroup`](crossbeam_utils::sync::WaitGroup),
+    // we can wait for any task that holds a cloned instance of it.
+    rayon::spawn({
         let sentry_client = sentry_client.clone();
+        let task_wait_ticket = config.waitgroup.clone();
         move || {
             let body_text = match std::str::from_utf8(&body).context("invalid UTF-8 in body") {
                 Ok(body) => body,
@@ -70,6 +70,7 @@ pub(crate) async fn handle_logs(
             if let Err(err) = process_logs(sentry_client, body_text) {
                 warn!("error processing logs: {:?}", err);
             }
+            drop(task_wait_ticket);
         }
     });
 
@@ -84,6 +85,7 @@ mod tests {
         body::Body,
         http::{Request, StatusCode},
     };
+    use crossbeam_utils::sync::WaitGroup;
     use tower::ServiceExt;
 
     #[tokio::test]
@@ -178,10 +180,11 @@ mod tests {
         assert_eq!(body, "Header of type `logplex-drain-token` was missing");
     }
 
-    #[test]
-    fn test_end_to_end_with_shutdown() {
+    #[tokio::test]
+    async fn test_end_to_end_with_shutdown() {
         let _ = initialize_tracing();
-        let config = Config::default();
+        let wg = WaitGroup::new();
+        let config = Config::default().with_waitgroup(wg.clone());
 
         let input = "
             111 <158>1 2022-12-05T08:59:21.850424+00:00 host heroku router - \
@@ -192,16 +195,8 @@ mod tests {
             status=503 bytes=0 protocol=https\
             ";
 
-        // not using `#[tokio::test]` so we can drop the runtime below
-        // and force the pending blocking tasks to be finished.
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-
-        let test_sentry_transport = runtime.block_on(config.with_captured_sentry_transport_async(
-            "real_token",
-            |_, config| async move {
+        let test_sentry_transport = config
+            .with_captured_sentry_transport_async("real_token", |_, config| async move {
                 let app = build_app(config.clone());
                 let response = app
                     .oneshot(
@@ -216,12 +211,11 @@ mod tests {
                 assert_eq!(response.status(), StatusCode::OK);
                 let bytes = hyper::body::to_bytes(response.into_body()).await.unwrap();
                 assert!(bytes.is_empty());
-            },
-        ));
+            })
+            .await;
 
-        // this should wait for all pending `spawn_blocking` tasks from handling
-        // the request above.
-        drop(runtime);
+        // wait for async tasks to finish
+        wg.wait();
 
         let events: Vec<sentry::protocol::Event<'static>> = test_sentry_transport
             .fetch_and_clear_envelopes()


### PR DESCRIPTION
This change will limit the amount of parallel background processing tasks to the rayon default (which is the CPU core count), compared to nearly unbounded growth of the tokio blocking threadpool, which is not designed for CPU bound work. 

resolves #57 

related docs: 
- https://docs.rs/rayon-core/latest/rayon_core/fn.spawn.html
- https://docs.rs/crossbeam-utils/latest/crossbeam_utils/sync/struct.WaitGroup.html