### PR TITLE
optionally enable sentry performance tracing

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -34,16 +34,13 @@ impl Config {
         debug!("loading config");
         let mut config = Config {
             port: env::var("PORT")
-                .context("could not find PORT in environment")
-                .and_then(|var| var.parse::<u16>().context("could not parse PORT"))
+                .unwrap_or("".into())
+                .parse::<u16>()
                 .unwrap_or(3000),
             sentry_dsn: env::var("SENTRY_DSN").ok(),
             sentry_traces_sample_rate: env::var("SENTRY_TRACES_SAMPLE_RATE")
-                .context("could not find SENTRY_TRACES_SAMPLE_RATE in environment")
-                .and_then(|var| {
-                    var.parse::<f32>()
-                        .context("could not parse sentry_traces_sample_rate")
-                })
+                .unwrap_or("".into())
+                .parse::<f32>()
                 .unwrap_or(0.0),
             sentry_debug: env::var("SENTRY_DEBUG")
                 .map(|var| !var.is_empty())

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context as _, Result};
+use anyhow::Result;
 use sentry::transports::DefaultTransportFactory;
 use std::{borrow::Cow, collections::HashMap, env, sync::Arc};
 use tracing::{debug, error, info, instrument};

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ async fn main() -> Result<()> {
                 release: heroku_release.map(Cow::Owned),
                 attach_stacktrace: true,
                 debug: config.sentry_debug,
+                traces_sample_rate: config.sentry_traces_sample_rate,
                 ..Default::default()
             }
             .add_integration(sentry_panic::PanicIntegration::default()),


### PR DESCRIPTION
Fixes #3  

The automatic instrumentation for `tracing::instrument` methods will work directly, 
the tower layers to trace requests are already set. 

see https://docs.sentry.io/platforms/rust/performance/instrumentation/automatic-instrumentation/ 

https://github.com/thermondo/log-reporter/blob/13275dc15e8234e8c00ebbdb71b67c7afa866ebd/src/main.rs#L61-L62


### missing 
missing is an end-to-end tracing (from request to finished parsing & sentry reporting), but IMO that's lower prio for now. 
can be done with https://docs.sentry.io/platforms/rust/performance/instrumentation/custom-instrumentation/ 