### PR TITLE
send heroku metrics to sentry metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,18 +28,18 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.80"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 dependencies = [
  "backtrace",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "461abc97219de0eaaf81fe3ef974a540158f3d079c2ab200f891f1a2ef201e85"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -449,9 +449,9 @@ checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
 name = "h2"
-version = "0.3.24"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
+checksum = "4fbd2820c5e49886948654ab546d0688ff24530286bdcf8fca3cefb16d4618eb"
 dependencies = [
  "bytes",
  "fnv",
@@ -468,9 +468,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31d030e59af851932b72ceebadf4a2b5986dba4c3b99dd2493f8273a0f151943"
+checksum = "51ee2dd2e4f378392eeff5d51618cd9a63166a2513846bbc55f21cfacd9199d4"
 dependencies = [
  "bytes",
  "fnv",
@@ -583,12 +583,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cb79eb393015dadd30fc252023adb0b2400a0caee0fa2a077e6e21a551e840"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http 1.1.0",
  "http-body 1.0.0",
  "pin-project-lite",
@@ -616,7 +616,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.24",
+ "h2 0.3.25",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -639,7 +639,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.2",
+ "h2 0.4.3",
  "http 1.1.0",
  "http-body 1.0.0",
  "httparse",
@@ -953,13 +953,13 @@ dependencies = [
 
 [[package]]
 name = "os_info"
-version = "3.7.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "006e42d5b888366f1880eda20371fedde764ed2213dc8496f49622fa0c99cd5e"
+checksum = "6cbb46d5d01695d7a1fb8be5f0d1968bd2b2b8ba1d1b3e7062ce2a0593e57af1"
 dependencies = [
  "log",
  "serde",
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1026,9 +1026,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1138,16 +1138,16 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.25"
+version = "0.11.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eea5a9eb898d3783f17c6407670e3592fd174cb81a10e51d4c37f49450b9946"
+checksum = "78bf93c4af7a8bb7d879d51cebe797356ff10ae8516ace542b5182d9dcac10b2"
 dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
  "futures-util",
- "h2 0.3.24",
+ "h2 0.3.25",
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.28",
@@ -1505,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "7383cd0e49fff4b6b90ca5670bfd3e9d6a733b3f90c686605aa7eec8c4996032"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1522,20 +1522,20 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "system-configuration"
-version = "0.6.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "658bc6ee10a9b4fcf576e9b0819d95ec16f4d2c02d39fd83ac1c8789785c4a42"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 1.3.2",
  "core-foundation",
  "system-configuration-sys",
 ]
 
 [[package]]
 name = "system-configuration-sys"
-version = "0.6.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1588,18 +1588,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,13 @@ edition = "2021"
 [dependencies]
 anyhow = "1.0.71"
 axum = { version = "0.7.3" }
-axum-extra = { version = "0.9.1", features = ["typed-header"]}
+axum-extra = { version = "0.9.1", features = ["typed-header"] }
 chrono = { version = "0.4.24", default-features = false }
 hyper = "1.1.0"
 crossbeam-utils = "0.8.15"
 nom = "7.1.3"
 rayon = "1.7.0"
-sentry = "0.32.1"
+sentry = { version = "0.32.1", features = ["UNSTABLE_metrics"] }
 sentry-anyhow = { version = "0.32.1", features = ["backtrace"] }
 sentry-panic = "0.32.1"
 sentry-tower = { version = "0.32.1", features = ["http"] }

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+[[disallowed-methods]]
+path = "sentry::metrics::Metric::send"
+reason = "Metric::send uses the wrong sentry Client for our use-case, use Client::add_metric"

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ pub(crate) struct Config {
     pub port: u16,
     pub sentry_dsn: Option<String>,
     pub sentry_debug: bool,
+    pub sentry_report_metrics: bool,
     pub sentry_traces_sample_rate: f32,
     pub sentry_clients: HashMap<String, Arc<sentry::Client>>,
     /// clone this waitgroup for anything that the app needs to wait
@@ -26,6 +27,7 @@ impl Default for Config {
             port: 3000,
             sentry_dsn: None,
             sentry_debug: false,
+            sentry_report_metrics: false,
             sentry_clients: HashMap::new(),
             waitgroup: None,
             sentry_traces_sample_rate: 0.0,
@@ -53,6 +55,9 @@ impl Config {
                 .parse::<f32>()
                 .unwrap_or(0.0),
             sentry_debug: env::var("SENTRY_DEBUG")
+                .map(|var| !var.is_empty())
+                .unwrap_or(false),
+            sentry_report_metrics: env::var("SENTRY_REPORT_METRICS")
                 .map(|var| !var.is_empty())
                 .unwrap_or(false),
             ..Default::default()

--- a/src/log_parser.rs
+++ b/src/log_parser.rs
@@ -76,7 +76,7 @@ pub(crate) fn parse_dyno_error_code(input: &str) -> IResult<&str, &str> {
     )(input)
 }
 
-pub(crate) fn parse_key_value_pairs(input: &str) -> IResult<&str, Vec<(String, String)>> {
+pub(crate) fn parse_key_value_pairs(input: &str) -> IResult<&str, Vec<(&str, &str)>> {
     many1(map(
         delimited(
             space0,
@@ -90,7 +90,7 @@ pub(crate) fn parse_key_value_pairs(input: &str) -> IResult<&str, Vec<(String, S
             )),
             space0,
         ),
-        |(key, _, value): (&str, &str, &str)| (key.to_owned(), value.to_owned()),
+        |(key, _, value): (&str, &str, &str)| (key, value),
     ))(input)
 }
 
@@ -336,21 +336,18 @@ mod tests {
         assert_eq!(
             result,
             vec![
-                ("at".into(), "info".into()),
-                ("method".into(), "GET".into(),),
-                ("path".into(), "/api/disposition/service/?hub=33".into(),),
-                ("host".into(), "thermondo-backend.herokuapp.com".into(),),
-                (
-                    "request_id".into(),
-                    "60fbbe6e-0ea5-4013-ab6a-9d6851fe1c95".into(),
-                ),
-                ("fwd".into(), "80.187.107.115,167.82.231.29".into(),),
-                ("dyno".into(), "web.10".into(),),
-                ("connect".into(), "2ms".into(),),
-                ("service".into(), "864ms".into(),),
-                ("status".into(), "200".into(),),
-                ("bytes".into(), "15055".into(),),
-                ("protocol".into(), "https".into(),),
+                ("at", "info"),
+                ("method", "GET"),
+                ("path", "/api/disposition/service/?hub=33"),
+                ("host", "thermondo-backend.herokuapp.com"),
+                ("request_id", "60fbbe6e-0ea5-4013-ab6a-9d6851fe1c95"),
+                ("fwd", "80.187.107.115,167.82.231.29"),
+                ("dyno", "web.10"),
+                ("connect", "2ms"),
+                ("service", "864ms"),
+                ("status", "200"),
+                ("bytes", "15055"),
+                ("protocol", "https"),
             ]
         );
     }
@@ -371,23 +368,20 @@ mod tests {
         assert_eq!(
             result,
             vec![
-                ("at".into(), "error".into()),
-                ("code".into(), "H12".into()),
-                ("desc".into(), "Request timeout".into()),
-                ("method".into(), "GET".into(),),
-                ("path".into(), "/".into(),),
-                ("host".into(), "myapp.herokuapp.com".into(),),
-                (
-                    "request_id".into(),
-                    "8601b555-6a83-4c12-8269-97c8e32cdb22".into(),
-                ),
-                ("fwd".into(), "204.204.204.204".into()),
-                ("dyno".into(), "web.1".into(),),
-                ("connect".into(), "0ms".into(),),
-                ("service".into(), "30000ms".into(),),
-                ("status".into(), "503".into(),),
-                ("bytes".into(), "0".into(),),
-                ("protocol".into(), "https".into(),),
+                ("at", "error"),
+                ("code", "H12"),
+                ("desc", "Request timeout"),
+                ("method", "GET"),
+                ("path", "/"),
+                ("host", "myapp.herokuapp.com"),
+                ("request_id", "8601b555-6a83-4c12-8269-97c8e32cdb22",),
+                ("fwd", "204.204.204.204"),
+                ("dyno", "web.1"),
+                ("connect", "0ms"),
+                ("service", "30000ms"),
+                ("status", "503"),
+                ("bytes", "0"),
+                ("protocol", "https"),
             ]
         );
     }
@@ -403,7 +397,7 @@ mod tests {
         let input: &str = "key=value and some text";
 
         let (remainder, result) = parse_key_value_pairs(input).expect("parse error");
-        assert_eq!(result, vec![("key".into(), "value".into())]);
+        assert_eq!(result, vec![("key", "value")]);
         assert_eq!(remainder, "and some text");
     }
 
@@ -416,13 +410,13 @@ mod tests {
         assert_eq!(
             result,
             vec![
-                ("source".into(), "web.1".into()),
+                ("source", "web.1"),
                 (
-                    "dyno".into(),
-                    "heroku.145151706.12daf639-fefc-4fba-9c12-d0f27c0a4604".into()
+                    "dyno",
+                    "heroku.145151706.12daf639-fefc-4fba-9c12-d0f27c0a4604"
                 ),
-                ("sample#memory_total".into(), "184.68MB".into()),
-                ("sample#memory_rss".into(), "158.27MB".into())
+                ("sample#memory_total", "184.68MB"),
+                ("sample#memory_rss", "158.27MB")
             ]
         );
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -145,10 +145,6 @@ fn parse_metric_from_kv<'a>(key: &'a str, value: &'a str) -> Result<SentryMetric
 
 /// generate router metrics from key/value pairs.
 /// These don't come in the metric format, but are just generated metrics based on the router log.
-///
-/// The additional 'a and 'b lifetime bounds in the return value shouldn't be needed because I don't
-/// use anything from the input iterator, but the compiler still wants them:
-/// https://users.rust-lang.org/t/96813/2
 fn generate_router_metrics<'a>(pairs: &'a LogMap<'a>) -> Vec<SentryMetric<'static>> {
     let mut result = Vec::with_capacity(4);
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -58,6 +58,7 @@ impl PartialEq for SentryMetric<'_> {
                 (MetricValue::Gauge(lhs), MetricValue::Gauge(rhs)) => lhs == rhs,
                 _ => false,
             })
+            && self.tags == other.tags
     }
 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -15,7 +15,7 @@ use sentry::{
 use std::{borrow::Cow, collections::HashMap};
 use tracing::{debug, warn};
 
-static PAGES: MetricUnit = MetricUnit::Custom(Cow::Borrowed("pages"));
+const PAGES: MetricUnit = MetricUnit::Custom(Cow::Borrowed("pages"));
 
 #[derive(Debug)]
 struct SentryMetric<'a> {
@@ -55,7 +55,7 @@ fn parse_metric_unit(unit: &str) -> IResult<&str, MetricUnit> {
             MetricUnit::Information(InformationUnit::Byte),
             all_consuming(tag_no_case("bytes")),
         ),
-        map(all_consuming(tag_no_case("pages")), |_| PAGES.clone()),
+        value(PAGES, all_consuming(tag_no_case("pages"))),
         value(
             MetricUnit::Duration(DurationUnit::MilliSecond),
             all_consuming(tag_no_case("ms")),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -248,7 +248,7 @@ fn generate_metrics<'a>(pairs: &'a LogMap) -> impl Iterator<Item = SentryMetric<
                 }
             };
 
-            metric.tags = tags.clone();
+            metric.tags.clone_from(&tags);
 
             Some(metric)
         })

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,237 @@
+use anyhow::{anyhow, bail, Context, Result};
+use sentry::{
+    metrics::{DurationUnit, InformationUnit, Metric, MetricUnit, MetricValue},
+    Client,
+};
+use std::{borrow::Cow, collections::HashMap};
+use tracing::{debug, warn};
+
+#[derive(Debug)]
+struct SentryMetric {
+    name: String,
+    value: MetricValue,
+    unit: MetricUnit,
+}
+
+impl PartialEq for SentryMetric {
+    fn eq(&self, other: &Self) -> bool {
+        self.name == other.name
+            && self.unit == other.unit
+            && (match (&self.value, &other.value) {
+                (MetricValue::Counter(lhs), MetricValue::Counter(rhs)) => lhs == rhs,
+                (MetricValue::Distribution(lhs), MetricValue::Distribution(rhs)) => lhs == rhs,
+                (MetricValue::Gauge(lhs), MetricValue::Gauge(rhs)) => lhs == rhs,
+                _ => false,
+            })
+    }
+}
+
+fn is_metric(key: &str) -> bool {
+    key.contains('#')
+}
+
+fn parse_metric_unit(unit: &str) -> MetricUnit {
+    // TODO: convert to `nom::tag_no_case` to safe allocations,
+    // TODO: make a normal parser so it can be combined in spilt_value_and_unit
+    match unit.to_ascii_lowercase().as_ref() {
+        "ms" => MetricUnit::Duration(DurationUnit::MilliSecond),
+        "s" => MetricUnit::Duration(DurationUnit::Second),
+        "mb" => MetricUnit::Information(InformationUnit::MebiByte),
+        "kb" => MetricUnit::Information(InformationUnit::KibiByte),
+        "bytes" => MetricUnit::Information(InformationUnit::Byte),
+        "pages" => MetricUnit::Custom("pages".into()),
+        _ if unit.is_empty() => MetricUnit::None,
+        _ => {
+            warn!(unit, "got custom metric unit");
+            MetricUnit::Custom(Cow::Owned(unit.to_owned()))
+        }
+    }
+}
+
+fn split_metric_value_and_unit(value: &str) -> Result<(f64, MetricUnit)> {
+    // TODO: convert to nom
+    let (value, unit) = {
+        if let Some(pos) = value.find(|c: char| !c.is_ascii_digit() && c != '.') {
+            value.split_at(pos)
+        } else {
+            (value, "")
+        }
+    };
+    let value: f64 = value.parse().context("can't parse metric value")?;
+    Ok((value, parse_metric_unit(unit)))
+}
+
+/// parses a key-value pair into a metric
+/// example source:
+///     key => sample#memory_total
+///     value => 196.79MB
+/// is already prevously split into key and value,
+/// here we're combining both again into a SentryMetric with name, value, unit.
+fn metric_from_kv<'a>(key: &'a str, value: &'a str) -> Result<SentryMetric> {
+    // TODO: convert to nom
+    let (kind, name) = key
+        .split_once('#')
+        .ok_or_else(|| anyhow!("missing separator in metric name"))?;
+
+    let (value, unit) = split_metric_value_and_unit(value)?;
+
+    Ok(SentryMetric {
+        name: name.to_owned(),
+        value: match kind {
+            "sample" => MetricValue::Gauge(value),
+            "count" => MetricValue::Counter(value),
+            "measure" => MetricValue::Distribution(value),
+            _ => bail!("unknown metric kind: {}", kind),
+        },
+        unit,
+    })
+}
+
+/// report router metrics to the sentry client.
+/// These don't come in the metric format, but are just generated metrics based on the router log.
+pub(crate) fn report_router_metrics<'a, I>(client: &Client, key_value_pairs: I) -> Result<()>
+where
+    I: Iterator<Item = (&'a str, &'a str)>,
+{
+    for (key, value) in key_value_pairs {
+        match key {
+            "bytes" => {
+                let value: u32 = value.parse().context("can't parse bytes")?;
+                client.add_metric(
+                    Metric::distribution("router.bytes", value as f64)
+                        .with_unit(MetricUnit::Information(InformationUnit::Byte))
+                        .finish(),
+                );
+            }
+            "connect" => {
+                let (value, unit) = split_metric_value_and_unit(value)?;
+                client.add_metric(
+                    Metric::distribution("router.connect", value)
+                        .with_unit(unit)
+                        .finish(),
+                );
+            }
+            "service" => {
+                let (value, unit) = split_metric_value_and_unit(value)?;
+                client.add_metric(
+                    Metric::distribution("router.service", value)
+                        .with_unit(unit)
+                        .finish(),
+                );
+            }
+            "status" => {
+                let status: u16 = value.parse().context("can't parse status code")?;
+                client.add_metric(
+                    Metric::count(format!(
+                        "router.status.{}",
+                        match status {
+                            200..=299 => "2xx",
+                            300..=399 => "3xx",
+                            400..=499 => "4xx",
+                            500..=599 => "5xx",
+                            _ => "xxx",
+                        }
+                    ))
+                    .finish(),
+                );
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+/// parse metrics from key-value pairs and report them to the sentry clients.
+/// Should understand:
+/// - native log-based metrics: https://devcenter.heroku.com/articles/librato#native-log-based-metrics
+/// - custom log-based metrics: https://devcenter.heroku.com/articles/librato#custom-log-based-metrics
+///
+/// Metric everything that is not a metric in the line like the dyno or source, will be convert
+/// into tags.
+///
+/// We don't support annotations yet.
+pub(crate) fn report_metrics<'a, I>(client: &Client, key_value_pairs: I) -> Result<()>
+where
+    I: Iterator<Item = (&'a str, &'a str)>,
+{
+    let mut tags: HashMap<String, String> = HashMap::new();
+
+    for (key, value) in key_value_pairs {
+        if is_metric(key) {
+            debug!(key, value, "got metric");
+            let metric = match metric_from_kv(key, value) {
+                Ok(result) => result,
+                Err(err) => {
+                    warn!(key, value, ?err, "couldn't parse metric");
+                    continue;
+                }
+            };
+
+            let mut builder =
+                Metric::build(metric.name.to_owned(), metric.value).with_unit(metric.unit);
+
+            for (tk, tv) in tags.iter() {
+                builder = builder.with_tag(tk.clone(), tv.clone());
+            }
+
+            let metric = builder.finish();
+
+            debug!(?metric, "sending metric");
+            client.add_metric(metric);
+        } else {
+            debug!(key, value, "got tag");
+            tags.insert(key.to_owned(), value.to_owned());
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_case::test_case;
+
+    #[test_case(
+        "sample#memory_total",
+        "196.79MB",
+        "memory_total",
+        MetricValue::Gauge(196.79),
+        MetricUnit::Information(InformationUnit::MebiByte)
+    )]
+    #[test_case(
+        "count#webhook.message.created.accepted",
+        "1",
+        "webhook.message.created.accepted",
+        MetricValue::Counter(1.0),
+        MetricUnit::None
+    )]
+    fn test_parse_metric_from_kv(
+        key: &str,
+        value: &str,
+        expected_name: &str,
+        expected_value: MetricValue,
+        expected_unit: MetricUnit,
+    ) {
+        assert_eq!(
+            metric_from_kv(key, value).unwrap(),
+            SentryMetric {
+                name: expected_name.into(),
+                value: expected_value,
+                unit: expected_unit
+            }
+        );
+    }
+
+    #[test_case("", MetricUnit::None)]
+    #[test_case("some_custom_value", MetricUnit::Custom("some_custom_value".into()))]
+    #[test_case("s", MetricUnit::Duration(DurationUnit::Second))]
+    #[test_case("mb", MetricUnit::Information(InformationUnit::MebiByte))]
+    #[test_case("kb", MetricUnit::Information(InformationUnit::KibiByte))]
+    #[test_case("bytes", MetricUnit::Information(InformationUnit::Byte))]
+    #[test_case("pages", MetricUnit::Custom("pages".into()))]
+    fn test_parse_metric_unit(unit: &str, expected_unit: MetricUnit) {
+        assert_eq!(parse_metric_unit(unit), expected_unit);
+    }
+}

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -192,12 +192,10 @@ pub(crate) fn process_logs(config: &Config, sentry_client: Arc<Client>, input: &
         } else if config.sentry_report_metrics {
             if let Ok((_remainder, pairs)) = parsed_key_value_pairs {
                 debug!("trying to report generic metrics");
-                if let Err(err) = report_metrics(
+                report_metrics(
                     &sentry_client,
                     pairs.iter().map(|(a, b)| (a.as_str(), b.as_str())),
-                ) {
-                    warn!(?err, ?pairs, "error reporting metrics");
-                }
+                )
             }
         }
     }

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -129,7 +129,7 @@ pub(crate) fn process_logs(config: &Config, sentry_client: Arc<Client>, input: &
             .context("could not parse log line")?;
 
         let parse_pairs = || {
-            parse_key_value_pairs(&log.text)
+            parse_key_value_pairs(log.text)
                 .map_err(|err| err.to_owned())
                 .with_context(|| format!("could not parse key value pairs from {}", log.text))
                 .map(|(_, pairs)| pairs)
@@ -172,7 +172,7 @@ pub(crate) fn process_logs(config: &Config, sentry_client: Arc<Client>, input: &
                     send_to_sentry(sentry_client.clone(), msg);
                 }
             }
-        } else if let Ok((_, code)) = parse_dyno_error_code(&log.text) {
+        } else if let Ok((_, code)) = parse_dyno_error_code(log.text) {
             if config.sentry_report_metrics {
                 sentry_client.add_metric(Metric::count(format!("errors.runtime.{code}")).finish());
             }

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -143,12 +143,10 @@ pub(crate) fn process_logs(config: &Config, sentry_client: Arc<Client>, input: &
 
             if config.sentry_report_metrics {
                 debug!("trying to report router metrics");
-                if let Err(err) = report_router_metrics(
+                report_router_metrics(
                     &sentry_client,
                     pairs.iter().map(|(a, b)| (a.as_str(), b.as_str())),
-                ) {
-                    warn!(?err, ?pairs, "error reporting router metrics");
-                }
+                );
             }
 
             let map: HashMap<String, String> = HashMap::from_iter(pairs.into_iter());

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -136,10 +136,11 @@ pub(crate) fn process_logs(config: &Config, sentry_client: Arc<Client>, input: &
             parse_key_value_pairs(&log.text)
                 .map_err(|err| err.to_owned())
                 .with_context(|| format!("could not parse key value pairs from {}", log.text))
+                .map(|(_, pairs)| pairs)
         };
 
         if matches!(log.kind, Kind::Heroku) && log.source == "router" {
-            let (_, pairs) = parse_pairs()?;
+            let pairs = parse_pairs()?;
 
             if config.sentry_report_metrics {
                 debug!("trying to report router metrics");
@@ -187,7 +188,7 @@ pub(crate) fn process_logs(config: &Config, sentry_client: Arc<Client>, input: &
                 }
             }
         } else if config.sentry_report_metrics {
-            if let Ok((_remainder, pairs)) = parse_pairs() {
+            if let Ok(pairs) = parse_pairs() {
                 debug!("trying to report generic metrics");
                 report_metrics(&sentry_client, pairs.iter().copied())
             }

--- a/src/server.rs
+++ b/src/server.rs
@@ -63,6 +63,7 @@ pub(crate) async fn handle_logs(
     // we can wait for any task that holds a cloned instance of it.
     {
         let sentry_client = sentry_client.clone();
+        let config = config.clone();
         let task_wait_ticket = config.waitgroup.clone();
         rayon::spawn(move || {
             let body_text = match std::str::from_utf8(&body).context("invalid UTF-8 in body") {
@@ -73,7 +74,7 @@ pub(crate) async fn handle_logs(
                 }
             };
 
-            if let Err(err) = process_logs(sentry_client, body_text) {
+            if let Err(err) = process_logs(&config, sentry_client, body_text) {
                 warn!("error processing logs: {:?}", err);
             }
             // we actually don't need the `drop` here,


### PR DESCRIPTION
TD-1121

This can replace what the [librato addon does](https://devcenter.heroku.com/articles/librato) for many apps / use-cases. 

Since we're consuming all logs already, and already have a link to sentry for errors, we can just parse the metrics from the log-stream, and convert them [to sentry metrics](https://blog.sentry.io/measure-what-matters-and-fix-issues-fast-with-metrics-now-in-beta/), and generate metrics from the router & error logs too. 

- For testing I deployed this change to `log-reporter-test`, and pointed `tmail` (prod) to this service. 
- some data visible in [this sentry dashboard](https://thermondo.sentry.io/dashboard/87947/?environment=production&project=1792001&statsPeriod=1h) 
