### PR TITLE
build docker container in tests, and test the image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         run: docker compose build web
 
       - name: start webserver
-        run: docker compose up web --detach
+        run: docker compose up web --wait
 
       - name: test HTTP request
         run: |


### PR DESCRIPTION
Prevents problems like https://github.com/thermondo/log-reporter/pull/290 directly in CI. 

( until now I manually tested each weekly update before deploying it to prod, this change saves me from this )