### PR TITLE
support metrics with dashes in their names or values

### DIFF
--- a/src/log_parser.rs
+++ b/src/log_parser.rs
@@ -85,7 +85,7 @@ pub(crate) fn parse_key_value_pairs(input: &str) -> IResult<&str, LogMap> {
             delimited(
                 space0,
                 tuple((
-                    take_while1(|c: char| c.is_alphanumeric() || c == '_' || c == '#'),
+                    take_while1(|c: char| c.is_alphanumeric() || c == '-' || c == '_' || c == '#'),
                     tag("="),
                     alt((
                         delimited(tag("\""), take_till1(|c: char| c == '"'), tag("\"")),
@@ -404,6 +404,18 @@ mod tests {
 
         let (remainder, result) = parse_key_value_pairs(input).expect("parse error");
         assert_eq!(result, LogMap::from_iter([("key", "value")]));
+        assert_eq!(remainder, "and some text");
+    }
+
+    #[test]
+    fn test_key_value_with_dashes_and_some_remainder() {
+        let input: &str = "sample#some-key=some-value and some text";
+
+        let (remainder, result) = parse_key_value_pairs(input).expect("parse error");
+        assert_eq!(
+            result,
+            LogMap::from_iter([("sample#some-key", "some-value")])
+        );
         assert_eq!(remainder, "and some text");
     }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -274,6 +274,13 @@ mod tests {
         MetricUnit::Information(InformationUnit::MebiByte)
     )]
     #[test_case(
+        "sample#memory-dash",
+        "196.79MB",
+        "memory-dash",
+        MetricValue::Gauge(196.79),
+        MetricUnit::Information(InformationUnit::MebiByte)
+    )]
+    #[test_case(
         "count#webhook.message.created.accepted",
         "1",
         "webhook.message.created.accepted",


### PR DESCRIPTION
I was missing some of the metrics. 
example line: 
```
735 <134>1 2024-05-16T08:11:59+00:00 host app heroku-postgres - source=HEROKU_POSTGRESQL_BRONZE addon=postgresql-transparent-10671 sample#current_transaction=1022676421 sample#db_size=334351430191bytes sample#tables=490 sample#active-connections=100 sample#waiting-connections=0 sample#index-cache-hit-rate=1 sample#table-cache-hit-rate=0.99999 sample#load-avg-1m=0.075 sample#load-avg-5m=0.13375 sample#load-avg-15m=0.14 sample#read-iops=0 sample#write-iops=1.4022 sample#tmp-disk-used=543633408 sample#tmp-disk-available=72435159040 sample#memory-total=65024544kB sample#memory-free=4224928kB sample#memory-cached=55920432kB sample#memory-postgres=2000488kB sample#follower-lag-commits=176 sample#wal-percentage-used=0.06867525261611022
```

where most postgres metrics were missing. 