### PR TITLE
keep dyno counts

### DIFF
--- a/src/background.rs
+++ b/src/background.rs
@@ -1,0 +1,36 @@
+use crate::{
+    config::Config,
+    log_parser::ScalingEvent,
+    metrics::{generate_scaling_metrics, report_metrics},
+};
+use std::{sync::Arc, time::Duration};
+use tokio::time::sleep;
+use tracing::debug;
+
+/// when sending scaling events to sentry as gauge,
+/// we have an issue where sentry would report the dyno count as
+/// "not reported" or zero between scaling events.
+///
+/// So we just store the last reported values and then regularly
+/// re-send them.
+/// due to how tokio works this spawned task won't block the server shutdown.
+pub(crate) async fn resend_scaling_events(config: Arc<Config>) {
+    loop {
+        sleep(Duration::from_secs(30)).await;
+
+        for (_, destination) in config.destinations.iter() {
+            let last_scaling_events = destination.last_scaling_events.lock().unwrap();
+
+            if let Some(events) = &*last_scaling_events {
+                let events: Vec<ScalingEvent<'_>> = events.iter().map(Into::into).collect();
+
+                debug!("resending scaling metrics");
+
+                report_metrics(
+                    &destination,
+                    generate_scaling_metrics(&events, "thermondo_log_reporter"),
+                );
+            }
+        }
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,13 +13,18 @@ use tracing::{debug, error, info, instrument};
 use std::future::Future;
 
 #[derive(Debug, Clone)]
+pub(crate) struct Destination {
+    pub(crate) sentry_client: Arc<sentry::Client>,
+}
+
+#[derive(Debug, Clone)]
 pub(crate) struct Config {
     pub port: u16,
     pub sentry_dsn: Option<String>,
     pub sentry_debug: bool,
     pub sentry_report_metrics: bool,
     pub sentry_traces_sample_rate: f32,
-    pub sentry_clients: HashMap<String, Arc<sentry::Client>>,
+    pub destinations: HashMap<String, Arc<Destination>>,
     /// clone this waitgroup for anything that the app needs to wait
     /// for when shutting down.
     /// See also [`WaitGroup`](crossbeam_utils::sync::WaitGroup).
@@ -33,7 +38,7 @@ impl Default for Config {
             sentry_dsn: None,
             sentry_debug: false,
             sentry_report_metrics: false,
-            sentry_clients: HashMap::new(),
+            destinations: HashMap::new(),
             waitgroup: Arc::new(RwLock::new(Some(WaitGroup::new()))),
             sentry_traces_sample_rate: 0.0,
         }
@@ -54,8 +59,8 @@ impl Config {
         }
 
         info!("flushing sentry events");
-        for client in self.sentry_clients.values() {
-            client.close(None);
+        for destination in self.destinations.values() {
+            destination.sentry_client.close(None);
         }
     }
 
@@ -106,9 +111,12 @@ impl Config {
                     },
                 ));
                 if client.is_enabled() {
-                    config
-                        .sentry_clients
-                        .insert(logplex_token.to_owned(), Arc::new(client));
+                    config.destinations.insert(
+                        logplex_token.to_owned(),
+                        Arc::new(Destination {
+                            sentry_client: Arc::new(client),
+                        }),
+                    );
 
                     info!(
                         ?logplex_token,
@@ -136,7 +144,7 @@ impl Config {
     pub(crate) async fn with_captured_sentry_events_async<F>(
         self,
         logplex_token: &str,
-        f: impl FnOnce(Arc<sentry::Client>, Arc<Config>) -> F,
+        f: impl FnOnce(Arc<Destination>, Arc<Config>) -> F,
     ) -> Vec<sentry::protocol::Event<'static>>
     where
         F: Future<Output = ()>,
@@ -155,7 +163,7 @@ impl Config {
     pub(crate) async fn with_captured_sentry_transport_async<F>(
         mut self,
         logplex_token: &str,
-        f: impl FnOnce(Arc<sentry::Client>, Arc<Config>) -> F,
+        f: impl FnOnce(Arc<Destination>, Arc<Config>) -> F,
     ) -> Arc<Arc<sentry::test::TestTransport>>
     where
         F: Future<Output = ()>,
@@ -168,12 +176,15 @@ impl Config {
                 ..Default::default()
             },
         )));
-        self.sentry_clients
-            .insert(logplex_token.to_owned(), client.clone());
+        let dest = Arc::new(Destination {
+            sentry_client: client.clone(),
+        });
+        self.destinations
+            .insert(logplex_token.to_owned(), dest.clone());
 
-        f(client, Arc::new(self.clone())).await;
+        f(dest, Arc::new(self.clone())).await;
 
-        self.sentry_clients.remove(&logplex_token.to_owned());
+        self.destinations.remove(&logplex_token.to_owned());
         test_transport
     }
 
@@ -181,17 +192,16 @@ impl Config {
     pub(crate) fn with_captured_sentry_events_sync(
         self,
         logplex_token: &str,
-        f: impl FnOnce(Arc<sentry::Client>, Arc<Config>),
+        f: impl FnOnce(Arc<Destination>, Arc<Config>),
     ) -> Vec<sentry::protocol::Event<'static>> {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .build()
             .expect("can't build runtime");
 
         runtime.block_on(async move {
-            self.with_captured_sentry_events_async(
-                logplex_token,
-                |cl, cfg| async move { f(cl, cfg) },
-            )
+            self.with_captured_sentry_events_async(logplex_token, |dest, cfg| async move {
+                f(dest, cfg)
+            })
             .await
         })
     }

--- a/src/log_parser.rs
+++ b/src/log_parser.rs
@@ -66,6 +66,23 @@ pub(crate) struct ScalingEvent<'a> {
     pub(crate) size: &'a str,
 }
 
+#[derive(Debug, Clone)]
+pub(crate) struct OwnedScalingEvent {
+    pub(crate) proc: String,
+    pub(crate) count: u16,
+    pub(crate) size: String,
+}
+
+impl<'a> From<&ScalingEvent<'a>> for OwnedScalingEvent {
+    fn from(value: &ScalingEvent<'a>) -> Self {
+        Self {
+            proc: value.proc.into(),
+            count: value.count,
+            size: value.size.into(),
+        }
+    }
+}
+
 /// parses heroku scaling events
 /// format like:
 ///     Scaled to web@4:Standard-1X worker@3:Standard-2X by user heroku.hirefire.api@thermondo.de

--- a/src/log_parser.rs
+++ b/src/log_parser.rs
@@ -66,6 +66,16 @@ pub(crate) struct ScalingEvent<'a> {
     pub(crate) size: &'a str,
 }
 
+impl<'a> From<&'a OwnedScalingEvent> for ScalingEvent<'a> {
+    fn from(value: &'a OwnedScalingEvent) -> Self {
+        Self {
+            proc: &value.proc,
+            count: value.count,
+            size: &value.size,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct OwnedScalingEvent {
     pub(crate) proc: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@ use tower_http::trace::TraceLayer;
 use tracing::{info, instrument};
 use tracing_subscriber::{prelude::*, EnvFilter};
 
+mod background;
 mod config;
 mod extractors;
 mod log_parser;
@@ -55,6 +56,9 @@ async fn main() -> Result<()> {
         tracing_registry.init();
         None
     };
+
+    info!("starting background task: resend scaling events");
+    tokio::spawn(background::resend_scaling_events(config.clone()));
 
     let port = config.port;
     let app = build_app(config.clone()).layer(

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -8,14 +8,14 @@ use nom::{
     sequence::tuple,
     IResult,
 };
-use sentry::{
-    metrics::{DurationUnit, InformationUnit, Metric, MetricUnit, MetricValue},
-    Client,
-};
+use sentry::metrics::{DurationUnit, InformationUnit, Metric, MetricUnit, MetricValue};
 use std::{borrow::Cow, collections::HashMap};
 use tracing::{debug, warn};
 
-use crate::log_parser::{LogMap, ScalingEvent};
+use crate::{
+    config::Destination,
+    log_parser::{LogMap, ScalingEvent},
+};
 
 const PAGES: MetricUnit = MetricUnit::Custom(Cow::Borrowed("pages"));
 
@@ -275,12 +275,12 @@ pub(crate) fn generate_metrics<'a>(pairs: &'a LogMap) -> impl Iterator<Item = Se
 }
 
 pub(crate) fn report_metrics<'a>(
-    client: &Client,
+    destination: &Destination,
     metrics: impl IntoIterator<Item = SentryMetric<'a>>,
 ) {
     for metric in metrics {
         debug!(?metric, "sending metric");
-        client.add_metric(metric.into());
+        destination.sentry_client.add_metric(metric.into());
     }
 }
 

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -199,6 +199,13 @@ pub(crate) fn process_logs(
         {
             if let Ok((_, (events, user))) = parse_scaling_event(log.text) {
                 debug!("trying to report scaling metrics");
+
+                {
+                    // store the scaling events in a cache so we can regularly re-send them.
+                    let mut last_events = destination.last_scaling_events.lock().unwrap();
+                    *last_events = Some(events.iter().map(Into::into).collect());
+                }
+
                 report_metrics(&destination, generate_scaling_metrics(&events, user));
             }
         } else if config.sentry_report_metrics {

--- a/src/server.rs
+++ b/src/server.rs
@@ -34,8 +34,8 @@ pub(crate) async fn handle_logs(
     State(config): State<Arc<Config>>,
     body: Body,
 ) -> impl IntoResponse {
-    let sentry_client = match config.sentry_clients.get(logplex_token.as_str()) {
-        Some(client) => client,
+    let destination = match config.destinations.get(logplex_token.as_str()) {
+        Some(dest) => dest,
         None => {
             debug!(?logplex_token, "unknown logplex token");
             return StatusCode::BAD_REQUEST;
@@ -62,7 +62,7 @@ pub(crate) async fn handle_logs(
     // By using a [`WaitGroup`](crossbeam_utils::sync::WaitGroup),
     // we can wait for any task that holds a cloned instance of it.
     {
-        let sentry_client = sentry_client.clone();
+        let sentry_client = destination.clone();
         let config = config.clone();
         let task_wait_ticket = config.new_waitgroup_ticket();
         rayon::spawn(move || {


### PR DESCRIPTION
- **refactor destination config from just a client to a separate struct**
- **start saving / storing**
- **docs**
- **resend scaling metrics**
