### PR TITLE
send heroku scaling events as metrics to librato

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,6 +230,16 @@ dependencies = [
  "iana-time-zone",
  "num-traits",
  "windows-targets",
+]
+
+[[package]]
+name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -891,6 +911,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,6 +936,7 @@ dependencies = [
  "chrono",
  "crossbeam-utils",
  "hyper",
+ "mockito",
  "nom",
  "rayon",
  "reqwest",
@@ -971,6 +1002,30 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "mockito"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "652cd6d169a36eaf9d1e6bce1a221130439a966d7f27858af66a33a66e9c4ee2"
+dependencies = [
+ "assert-json-diff",
+ "bytes",
+ "colored",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "rand",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+ "tokio",
 ]
 
 [[package]]
@@ -1102,6 +1157,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1226,6 +1304,15 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1419,6 +1506,12 @@ checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -1664,6 +1757,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "similar"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1886,6 +1985,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,7 +216,10 @@ version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
  "num-traits",
+ "windows-targets",
 ]
 
 [[package]]
@@ -652,6 +670,29 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,6 +33,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -314,6 +320,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +470,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "h2"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
 name = "headers"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +590,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -553,6 +600,23 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -730,6 +794,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -793,7 +867,9 @@ dependencies = [
  "hyper",
  "nom",
  "rayon",
+ "reqwest",
  "sentry",
+ "serde_json",
  "test-case",
  "tokio",
  "tower",
@@ -1163,13 +1239,16 @@ checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -1185,6 +1264,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
+ "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tower",
@@ -1194,6 +1274,21 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-registry",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1225,6 +1320,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,6 +1346,17 @@ name = "rustls-pki-types"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustversion"
@@ -1529,10 +1648,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1563,6 +1694,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1722,6 +1874,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,6 +2015,12 @@ name = "unicode-ident"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
@@ -2231,6 +2412,12 @@ dependencies = [
  "syn",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zerovec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = "1.0.71"
 axum = { version = "0.8.1" }
 axum-extra = { version = "0.10.0", features = ["typed-header"] }
-chrono = { version = "0.4.24", default-features = false }
+chrono = { version = "0.4.24", default-features = false, features = ["clock"] }
 crossbeam-utils = "0.8.15"
 hyper = "1.1.0"
 nom = "7.1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,9 @@ crossbeam-utils = "0.8.15"
 hyper = "1.1.0"
 nom = "7.1.3"
 rayon = "1.7.0"
+reqwest = { version = "0.12.12", features = ["json"] }
 sentry = { version = "0.36.0", features = ["metrics", "panic", "tower-http", "tracing"] }
+serde_json = "1.0.135"
 tokio = { version = "1.28.0", features = [
   "rt-multi-thread",
   "macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tracing-subscriber = { version = "0.3.16", default-features = false, features = 
 uuid = "1.3.1"
 
 [dev-dependencies]
+mockito = "1.6.1"
 sentry = { version = "0.36.0", features = ["test"] }
 test-case = "3.1.0"
 tower = { version = "0.5.0", features = ["util"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -219,7 +219,7 @@ impl Config {
                 ..Default::default()
             },
         )));
-        let dest = Arc::new(Destination::new(client.clone()));
+        let dest = Arc::new(Destination::new(client.clone(), None));
         self.destinations
             .insert(logplex_token.to_owned(), dest.clone());
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -80,7 +80,7 @@ impl Config {
                 // since we might have running background send-to-librato tasks.
                 // the shutdown itself won't generate new tasks, so we're fine here.
                 if let Err(err) = librato_client.shutdown().await {
-                    warn!(
+                    error!(
                         ?err,
                         librato_client.username, "error shutting down librato client"
                     );

--- a/src/config.rs
+++ b/src/config.rs
@@ -147,7 +147,11 @@ impl Config {
                 if client.is_enabled() {
                     let librato_client =
                         if let (Some(username), Some(token)) = (pieces.get(3), pieces.get(4)) {
-                            Some(LibratoClient::new(username.to_string(), token.to_string()))
+                            Some(LibratoClient::new(
+                                username.to_string(),
+                                token.to_string(),
+                                config.new_waitgroup_ticket(),
+                            ))
                         } else {
                             None
                         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::{librato::LibratoClient, log_parser::OwnedScalingEvent};
+use crate::{librato, log_parser::OwnedScalingEvent};
 use anyhow::Result;
 use crossbeam_utils::sync::WaitGroup;
 use sentry::transports::DefaultTransportFactory;
@@ -17,7 +17,7 @@ use std::future::Future;
 pub(crate) struct Destination {
     pub(crate) sentry_client: Arc<sentry::Client>,
 
-    pub(crate) librato_client: Option<LibratoClient>,
+    pub(crate) librato_client: Option<librato::Client>,
 
     /// store the last seen scaling events so we can re-send them,
     /// assuming that the dyno counts don't change between scaling events.
@@ -27,7 +27,7 @@ pub(crate) struct Destination {
 impl Destination {
     pub(crate) fn new(
         sentry_client: Arc<sentry::Client>,
-        librato_client: Option<LibratoClient>,
+        librato_client: Option<librato::Client>,
     ) -> Self {
         Self {
             sentry_client,
@@ -148,7 +148,7 @@ impl Config {
                     let librato_client =
                         if let (Some(username), Some(token)) = (pieces.get(3), pieces.get(4)) {
                             info!(username, "configuring librato client");
-                            Some(LibratoClient::new(
+                            Some(librato::Client::new(
                                 username.to_string(),
                                 token.to_string(),
                                 config.new_waitgroup_ticket(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -152,10 +152,12 @@ impl Config {
                 if client.is_enabled() {
                     let librato_client = if let Some(&[username, token]) = pieces.get(3..=4) {
                         info!(username, "configuring librato client");
+                        let runtime = tokio::runtime::Handle::current();
                         Some(librato::Client::new(
                             username.to_string(),
                             token.to_string(),
                             config.new_waitgroup_ticket(),
+                            runtime,
                             #[cfg(test)]
                             "invalid_endpoint",
                         ))

--- a/src/config.rs
+++ b/src/config.rs
@@ -147,6 +147,7 @@ impl Config {
                 if client.is_enabled() {
                     let librato_client =
                         if let (Some(username), Some(token)) = (pieces.get(3), pieces.get(4)) {
+                            info!(username, "configuring librato client");
                             Some(LibratoClient::new(
                                 username.to_string(),
                                 token.to_string(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -157,7 +157,7 @@ impl Config {
                             token.to_string(),
                             config.new_waitgroup_ticket(),
                             #[cfg(test)]
-                            "",
+                            "invalid_endpoint",
                         ))
                     } else {
                         None

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,7 +8,7 @@ use std::{
     env,
     sync::{Arc, Mutex, RwLock},
 };
-use tracing::{debug, error, info, instrument};
+use tracing::{debug, error, info, instrument, warn};
 
 #[cfg(test)]
 use std::future::Future;
@@ -84,7 +84,12 @@ impl Config {
             destination.sentry_client.close(None);
 
             if let Some(librato_client) = &destination.librato_client {
-                librato_client.shutdown().await;
+                if let Err(err) = librato_client.shutdown().await {
+                    warn!(
+                        ?err,
+                        librato_client.username, "error shutting down librato client"
+                    );
+                };
             }
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -152,12 +152,10 @@ impl Config {
                 if client.is_enabled() {
                     let librato_client = if let Some(&[username, token]) = pieces.get(3..=4) {
                         info!(username, "configuring librato client");
-                        let runtime = tokio::runtime::Handle::current();
                         Some(librato::Client::new(
                             username.to_string(),
                             token.to_string(),
                             config.new_waitgroup_ticket(),
-                            runtime,
                             #[cfg(test)]
                             "invalid_endpoint",
                         ))

--- a/src/librato.rs
+++ b/src/librato.rs
@@ -6,13 +6,14 @@ use std::{
     sync::Mutex,
     time::{Duration, Instant},
 };
-use tracing::{debug, error, info};
+use tracing::{debug, error};
 
 const MAX_MEASURE_MEASUREMENTS_PER_REQUEST: usize = 300; // max as per documentation
 const FLUSH_INTERVAL: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Clone)]
 pub(crate) enum Kind {
+    #[allow(dead_code)]
     Counter,
     Gauge,
 }

--- a/src/librato.rs
+++ b/src/librato.rs
@@ -43,6 +43,9 @@ impl State {
     }
 }
 
+/// Librato client to send measurements to librato.
+/// collects metrics in an internal queue and regularly send them to librato
+/// in the background.
 #[derive(Debug)]
 pub(crate) struct Client {
     pub(crate) username: String,

--- a/src/librato.rs
+++ b/src/librato.rs
@@ -14,14 +14,14 @@ const FLUSH_INTERVAL: Duration = Duration::from_secs(60);
 #[cfg(not(test))]
 const DEFAULT_METRIC_ENDPOINT: &str = "https://metrics-api.librato.com/v1/metrics";
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) enum Kind {
     #[allow(dead_code)]
     Counter,
     Gauge,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) struct Measurement {
     pub(crate) kind: Kind,
     pub(crate) measure_time: DateTime<FixedOffset>,

--- a/src/librato.rs
+++ b/src/librato.rs
@@ -1,59 +1,117 @@
-use anyhow::Result;
+use anyhow::{bail, Result};
+use chrono::{DateTime, FixedOffset};
 use serde_json::json;
+use std::{
+    sync::Mutex,
+    time::{Duration, Instant},
+};
+use tracing::error;
 
-const LIRATO_USERNAME: &str = "heroku+76cc8300-be35-4c6c-a474-85836ca8c57e@solarwinds.com";
-const LIBRATO_TOKEN: &str = "8b41266ad8e23a240f7fef2359c88dac7f52a917d35148c994d32edfd8fc75a4";
+const MAX_MEASURE_MEASUREMENTS_PER_REQUEST: usize = 300;
+const FLUSH_INTERVAL: Duration = Duration::from_secs(60);
 
-/// uses old API http://api-docs-archive.librato.com/
-pub(crate) async fn test() -> Result<()> {
-    let response = reqwest::Client::new()
-        .post("https://metrics-api.librato.com/v1/metrics")
-        .basic_auth(LIRATO_USERNAME, Some(LIBRATO_TOKEN))
-        .json(&json!({
-           "measure_time": 1481637660,
-           "source": "my.app",
-           "gauges": [
-             {
-               "name": "cpu",
-               "value": 75,
-               "source": "my.machine"
-             }
-           ],
-           "counters": [
-             {
-               "name": "requests",
-               "value": 1,
-               "source": "my.machine"
-             }
-           ]
-        }))
-        .send()
-        .await?;
-
-    dbg!(&response.status());
-    dbg!(response.text().await?);
-
-    Ok(())
+#[derive(Debug, Clone)]
+pub(crate) enum Kind {
+    Counter,
+    Gauge,
 }
 
-// curl \
-//   -u $LIBRATO_USERNAME:$LIBRATO_TOKEN \
-//   -H "Content-Type: application/json" \
-//   -d '{
-//     "tags": {
-//       "region": "us-west",
-//       "name": "web-prod-3"
-//     },
-//     "measurements": [
-//       {
-//         "name": "cpu",
-//         "value": 4.5
-//       },
-//       {
-//         "name": "memory",
-//         "value": 10.5
-//       }
-//     ]
-//   }' \
-// -X POST \
-// https://metrics-api.librato.com/v1/measurements
+#[derive(Debug, Clone)]
+pub(crate) struct Measurement {
+    kind: Kind,
+    measure_time: DateTime<FixedOffset>,
+    value: f64,
+    name: String,
+    source: String,
+}
+
+struct State {
+    queue: Vec<Measurement>,
+    last_flush: Instant,
+}
+
+pub(crate) struct LibratoClient {
+    username: String,
+    token: String,
+    inner: Mutex<State>,
+}
+
+impl LibratoClient {
+    pub(crate) fn new(username: impl Into<String>, token: impl Into<String>) -> LibratoClient {
+        Self {
+            username: username.into(),
+            token: token.into(),
+            inner: Mutex::new(State {
+                queue: Vec::new(),
+                last_flush: Instant::now(),
+            }),
+        }
+    }
+
+    pub(crate) fn add_measurement(&self, measurement: Measurement) {
+        let mut state = self.inner.lock().unwrap();
+        state.queue.push(measurement);
+
+        if state.queue.len() > MAX_MEASURE_MEASUREMENTS_PER_REQUEST
+            || state.last_flush.elapsed() > FLUSH_INTERVAL
+        {
+            tokio::spawn({
+                let queue = state.queue.clone();
+                let username = self.username.clone();
+                let token = self.token.clone();
+                async move {
+                    if let Err(err) = LibratoClient::send(username, token, queue).await {
+                        error!(?err, "error sending metrics to librato");
+                    }
+                }
+            });
+            state.last_flush = Instant::now();
+            state.queue.clear();
+        }
+    }
+
+    /// uses old API http://api-docs-archive.librato.com/
+    pub(crate) async fn send(
+        username: String,
+        token: String,
+        measurements: Vec<Measurement>,
+    ) -> Result<()> {
+        let response = reqwest::Client::new()
+            .post("https://metrics-api.librato.com/v1/metrics")
+            .basic_auth(username, Some(token))
+            .json(&json!({
+               "gauges": measurements.iter().filter_map(|m| {
+                    matches!(m.kind, Kind::Gauge).then(|| {
+                        json!({
+                            "measure_time": m.measure_time.timestamp(),
+                            "name": m.name,
+                            "value": m.value,
+                            "source": m.source,
+                        })
+                    })
+                }).collect::<Vec<_>>(),
+               "counters": measurements.iter().filter_map(|m| {
+                    matches!(m.kind, Kind::Counter).then(|| {
+                        json!({
+                            "measure_time": m.measure_time.timestamp(),
+                            "name": m.name,
+                            "value": m.value,
+                            "source": m.source,
+                        })
+                    })
+                }).collect::<Vec<_>>(),
+            }))
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            bail!(
+                "librato returned an error code {}: {}",
+                response.status(),
+                response.text().await?
+            );
+        }
+
+        Ok(())
+    }
+}

--- a/src/librato.rs
+++ b/src/librato.rs
@@ -1,0 +1,59 @@
+use anyhow::Result;
+use serde_json::json;
+
+const LIRATO_USERNAME: &str = "heroku+76cc8300-be35-4c6c-a474-85836ca8c57e@solarwinds.com";
+const LIBRATO_TOKEN: &str = "8b41266ad8e23a240f7fef2359c88dac7f52a917d35148c994d32edfd8fc75a4";
+// TODO: usee old API http://api-docs-archive.librato.com/
+
+pub(crate) async fn test() -> Result<()> {
+    let response = reqwest::Client::new()
+        .post("https://metrics-api.librato.com/v1/metrics")
+        .basic_auth(LIRATO_USERNAME, Some(LIBRATO_TOKEN))
+        .json(&json!({
+           "measure_time": 1481637660,
+           "source": "my.app",
+           "gauges": [
+             {
+               "name": "cpu",
+               "value": 75,
+               "source": "my.machine"
+             }
+           ],
+           "counters": [
+             {
+               "name": "requests",
+               "value": 1,
+               "source": "my.machine"
+             }
+           ]
+        }))
+        .send()
+        .await?;
+
+    dbg!(&response.status());
+    dbg!(response.text().await?);
+
+    Ok(())
+}
+
+// curl \
+//   -u $LIBRATO_USERNAME:$LIBRATO_TOKEN \
+//   -H "Content-Type: application/json" \
+//   -d '{
+//     "tags": {
+//       "region": "us-west",
+//       "name": "web-prod-3"
+//     },
+//     "measurements": [
+//       {
+//         "name": "cpu",
+//         "value": 4.5
+//       },
+//       {
+//         "name": "memory",
+//         "value": 10.5
+//       }
+//     ]
+//   }' \
+// -X POST \
+// https://metrics-api.librato.com/v1/measurements

--- a/src/librato.rs
+++ b/src/librato.rs
@@ -6,6 +6,7 @@ use std::{
     sync::Mutex,
     time::{Duration, Instant},
 };
+use tokio::runtime::Handle;
 use tracing::{debug, error};
 
 const MAX_MEASURE_MEASUREMENTS_PER_REQUEST: usize = 300; // max as per documentation
@@ -50,6 +51,7 @@ pub(crate) struct Client {
     #[cfg(test)]
     endpoint: String,
     inner: Mutex<State>,
+    runtime: Handle,
 }
 
 impl Client {
@@ -57,9 +59,11 @@ impl Client {
         username: impl Into<String>,
         token: impl Into<String>,
         waitgroup: Option<WaitGroup>,
+        runtime: Handle,
         #[cfg(test)] endpoint: impl Into<String>,
     ) -> Client {
         Self {
+            runtime,
             username: username.into(),
             token: token.into(),
             #[cfg(test)]
@@ -83,7 +87,7 @@ impl Client {
             || state.last_flush.elapsed() > FLUSH_INTERVAL
         {
             debug!(?state.queue, "triggering background flushing to librato");
-            tokio::spawn({
+            self.runtime.spawn({
                 let queue = state.queue.clone();
                 let username = self.username.clone();
                 let token = self.token.clone();
@@ -189,14 +193,26 @@ mod tests {
 
     #[tokio::test]
     async fn test_empty_shutdown() {
-        let client = Client::new("username", "token", None, "invalid_endpoint");
+        let client = Client::new(
+            "username",
+            "token",
+            None,
+            Handle::current(),
+            "invalid_endpoint",
+        );
 
         assert!(client.shutdown().await.is_ok());
     }
 
     #[tokio::test]
     async fn test_shutdown_fails_with_queued_measurements() {
-        let client = Client::new("username", "token", None, "invalid_endpoint");
+        let client = Client::new(
+            "username",
+            "token",
+            None,
+            Handle::current(),
+            "invalid_endpoint",
+        );
         client.add_measurement(Measurement {
             kind: Kind::Gauge,
             measure_time: chrono::Utc::now().into(),
@@ -233,7 +249,7 @@ mod tests {
             })
             .create();
 
-        let client = Client::new("username", "token", None, server.url());
+        let client = Client::new("username", "token", None, Handle::current(), server.url());
         client.add_measurement(Measurement {
             kind: Kind::Gauge,
             measure_time: timestamp.into(),

--- a/src/librato.rs
+++ b/src/librato.rs
@@ -3,8 +3,8 @@ use serde_json::json;
 
 const LIRATO_USERNAME: &str = "heroku+76cc8300-be35-4c6c-a474-85836ca8c57e@solarwinds.com";
 const LIBRATO_TOKEN: &str = "8b41266ad8e23a240f7fef2359c88dac7f52a917d35148c994d32edfd8fc75a4";
-// TODO: usee old API http://api-docs-archive.librato.com/
 
+/// uses old API http://api-docs-archive.librato.com/
 pub(crate) async fn test() -> Result<()> {
     let response = reqwest::Client::new()
         .post("https://metrics-api.librato.com/v1/metrics")

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,7 +80,7 @@ async fn main() -> Result<()> {
         .with_graceful_shutdown(shutdown_signal())
         .await?;
 
-    config.shutdown();
+    config.shutdown().await;
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use tracing_subscriber::{prelude::*, EnvFilter};
 mod background;
 mod config;
 mod extractors;
+mod librato;
 mod log_parser;
 mod metrics;
 mod reporter;
@@ -26,62 +27,64 @@ mod test_utils;
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
-    let config = Arc::new(config::Config::init_from_env()?);
-    info!(?config, "config loaded");
-
-    let heroku_release = std::env::var("HEROKU_RELEASE_VERSION").ok();
-
-    let mut tracing_subscriber_layer = tracing_subscriber::fmt::layer();
-
-    if heroku_release.is_some() {
-        // we don't want ansi colors on heroku since logentries doesnt understand them.
-        tracing_subscriber_layer = tracing_subscriber_layer.with_ansi(false);
-    }
-
-    let tracing_registry = tracing_subscriber::registry()
-        .with(tracing_subscriber_layer)
-        .with(EnvFilter::from_default_env());
-
-    let _sentry_guard = if let Some(sentry_dsn) = &config.sentry_dsn {
-        tracing_registry.with(sentry_tracing::layer()).init();
-        Some(sentry::init((
-            sentry_dsn.clone(),
-            sentry::ClientOptions {
-                release: heroku_release.map(Cow::Owned),
-                attach_stacktrace: true,
-                debug: config.sentry_debug,
-                traces_sample_rate: config.sentry_traces_sample_rate,
-                ..Default::default()
-            }
-            .add_integration(sentry_panic::PanicIntegration::default()),
-        )))
-    } else {
-        tracing_registry.init();
-        None
-    };
-
-    info!("starting background task: resend scaling events");
-    tokio::spawn(background::resend_scaling_events(config.clone()));
-
-    let port = config.port;
-    let app = build_app(config.clone()).layer(
-        ServiceBuilder::new()
-            .layer(TraceLayer::new_for_http())
-            .layer(sentry_tower::NewSentryLayer::new_from_top())
-            .layer(sentry_tower::SentryHttpLayer::with_transaction()),
-    );
-
-    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
-    info!(?addr, "starting server");
-
-    let listener = TcpListener::bind(addr).await?;
-    axum::serve(listener, app.into_make_service())
-        .with_graceful_shutdown(shutdown_signal())
-        .await?;
-
-    config.shutdown();
-
+    librato::test().await?;
     Ok(())
+    // let config = Arc::new(config::Config::init_from_env()?);
+    // info!(?config, "config loaded");
+
+    // let heroku_release = std::env::var("HEROKU_RELEASE_VERSION").ok();
+
+    // let mut tracing_subscriber_layer = tracing_subscriber::fmt::layer();
+
+    // if heroku_release.is_some() {
+    //     // we don't want ansi colors on heroku since logentries doesnt understand them.
+    //     tracing_subscriber_layer = tracing_subscriber_layer.with_ansi(false);
+    // }
+
+    // let tracing_registry = tracing_subscriber::registry()
+    //     .with(tracing_subscriber_layer)
+    //     .with(EnvFilter::from_default_env());
+
+    // let _sentry_guard = if let Some(sentry_dsn) = &config.sentry_dsn {
+    //     tracing_registry.with(sentry_tracing::layer()).init();
+    //     Some(sentry::init((
+    //         sentry_dsn.clone(),
+    //         sentry::ClientOptions {
+    //             release: heroku_release.map(Cow::Owned),
+    //             attach_stacktrace: true,
+    //             debug: config.sentry_debug,
+    //             traces_sample_rate: config.sentry_traces_sample_rate,
+    //             ..Default::default()
+    //         }
+    //         .add_integration(sentry_panic::PanicIntegration::default()),
+    //     )))
+    // } else {
+    //     tracing_registry.init();
+    //     None
+    // };
+
+    // info!("starting background task: resend scaling events");
+    // tokio::spawn(background::resend_scaling_events(config.clone()));
+
+    // let port = config.port;
+    // let app = build_app(config.clone()).layer(
+    //     ServiceBuilder::new()
+    //         .layer(TraceLayer::new_for_http())
+    //         .layer(sentry_tower::NewSentryLayer::new_from_top())
+    //         .layer(sentry_tower::SentryHttpLayer::with_transaction()),
+    // );
+
+    // let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
+    // info!(?addr, "starting server");
+
+    // let listener = TcpListener::bind(addr).await?;
+    // axum::serve(listener, app.into_make_service())
+    //     .with_graceful_shutdown(shutdown_signal())
+    //     .await?;
+
+    // config.shutdown();
+
+    // Ok(())
 }
 
 #[instrument]

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,64 +27,62 @@ mod test_utils;
 
 #[tokio::main(flavor = "multi_thread")]
 async fn main() -> Result<()> {
-    librato::test().await?;
+    let config = Arc::new(config::Config::init_from_env()?);
+    info!(?config, "config loaded");
+
+    let heroku_release = std::env::var("HEROKU_RELEASE_VERSION").ok();
+
+    let mut tracing_subscriber_layer = tracing_subscriber::fmt::layer();
+
+    if heroku_release.is_some() {
+        // we don't want ansi colors on heroku since logentries doesnt understand them.
+        tracing_subscriber_layer = tracing_subscriber_layer.with_ansi(false);
+    }
+
+    let tracing_registry = tracing_subscriber::registry()
+        .with(tracing_subscriber_layer)
+        .with(EnvFilter::from_default_env());
+
+    let _sentry_guard = if let Some(sentry_dsn) = &config.sentry_dsn {
+        tracing_registry.with(sentry_tracing::layer()).init();
+        Some(sentry::init((
+            sentry_dsn.clone(),
+            sentry::ClientOptions {
+                release: heroku_release.map(Cow::Owned),
+                attach_stacktrace: true,
+                debug: config.sentry_debug,
+                traces_sample_rate: config.sentry_traces_sample_rate,
+                ..Default::default()
+            }
+            .add_integration(sentry_panic::PanicIntegration::default()),
+        )))
+    } else {
+        tracing_registry.init();
+        None
+    };
+
+    info!("starting background task: resend scaling events");
+    tokio::spawn(background::resend_scaling_events(config.clone()));
+
+    let port = config.port;
+    let app = build_app(config.clone()).layer(
+        ServiceBuilder::new()
+            .layer(TraceLayer::new_for_http())
+            .layer(sentry_tower::NewSentryLayer::new_from_top())
+            .layer(sentry_tower::SentryHttpLayer::with_transaction()),
+    );
+
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
+    info!(?addr, "starting server");
+
+    let listener = TcpListener::bind(addr).await?;
+    axum::serve(listener, app.into_make_service())
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    config.shutdown();
+
     Ok(())
-    // let config = Arc::new(config::Config::init_from_env()?);
-    // info!(?config, "config loaded");
-
-    // let heroku_release = std::env::var("HEROKU_RELEASE_VERSION").ok();
-
-    // let mut tracing_subscriber_layer = tracing_subscriber::fmt::layer();
-
-    // if heroku_release.is_some() {
-    //     // we don't want ansi colors on heroku since logentries doesnt understand them.
-    //     tracing_subscriber_layer = tracing_subscriber_layer.with_ansi(false);
-    // }
-
-    // let tracing_registry = tracing_subscriber::registry()
-    //     .with(tracing_subscriber_layer)
-    //     .with(EnvFilter::from_default_env());
-
-    // let _sentry_guard = if let Some(sentry_dsn) = &config.sentry_dsn {
-    //     tracing_registry.with(sentry_tracing::layer()).init();
-    //     Some(sentry::init((
-    //         sentry_dsn.clone(),
-    //         sentry::ClientOptions {
-    //             release: heroku_release.map(Cow::Owned),
-    //             attach_stacktrace: true,
-    //             debug: config.sentry_debug,
-    //             traces_sample_rate: config.sentry_traces_sample_rate,
-    //             ..Default::default()
-    //         }
-    //         .add_integration(sentry_panic::PanicIntegration::default()),
-    //     )))
-    // } else {
-    //     tracing_registry.init();
-    //     None
-    // };
-
-    // info!("starting background task: resend scaling events");
-    // tokio::spawn(background::resend_scaling_events(config.clone()));
-
-    // let port = config.port;
-    // let app = build_app(config.clone()).layer(
-    //     ServiceBuilder::new()
-    //         .layer(TraceLayer::new_for_http())
-    //         .layer(sentry_tower::NewSentryLayer::new_from_top())
-    //         .layer(sentry_tower::SentryHttpLayer::with_transaction()),
-    // );
-
-    // let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), port);
-    // info!(?addr, "starting server");
-
-    // let listener = TcpListener::bind(addr).await?;
-    // axum::serve(listener, app.into_make_service())
-    //     .with_graceful_shutdown(shutdown_signal())
-    //     .await?;
-
-    // config.shutdown();
-
-    // Ok(())
 }
 
 #[instrument]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -159,7 +159,7 @@ pub(crate) fn generate_librato_scaling_metrics(
     timestamp: &DateTime<FixedOffset>,
     events: &[ScalingEvent<'_>],
 ) -> Vec<librato::Measurement> {
-    let mut result = Vec::with_capacity(events.len());
+    let mut result = Vec::with_capacity(events.len() * 2);
 
     for event in events {
         result.push(librato::Measurement {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -167,7 +167,7 @@ pub(crate) fn generate_librato_scaling_metrics(
             kind: librato::Kind::Gauge,
             value: event.count as f64,
             source: event.proc.to_string(),
-            name: format!("dyno_count.{}", event.size),
+            name: format!("dyno_count.{}", event.size.to_lowercase()),
         });
         result.push(librato::Measurement {
             measure_time: *timestamp,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -330,7 +330,10 @@ pub(crate) fn report_metrics<'a>(
 
 #[cfg(test)]
 mod tests {
+    use self::librato::{Kind, Measurement};
+
     use super::*;
+    use chrono::Local;
     use test_case::test_case;
 
     #[test_case(
@@ -500,6 +503,39 @@ mod tests {
                     value: MetricValue::Counter(1.0),
                     unit: MetricUnit::None,
                     tags: expected_tags.clone(),
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_generate_librato_scaling_metrics() {
+        let ts = Local::now().fixed_offset();
+        let result = generate_librato_scaling_metrics(
+            &ts,
+            &[ScalingEvent {
+                proc: "web",
+                count: 99,
+                size: "huuuuge-2X",
+            }],
+        );
+
+        assert_eq!(
+            result,
+            vec![
+                Measurement {
+                    measure_time: ts,
+                    kind: Kind::Gauge,
+                    name: "dyno_count.huuuuge-2x".into(),
+                    value: 99.0,
+                    source: "web".into()
+                },
+                Measurement {
+                    measure_time: ts,
+                    kind: Kind::Gauge,
+                    name: "dyno_count".into(),
+                    value: 99.0,
+                    source: "web".into()
                 },
             ]
         );

--- a/src/server.rs
+++ b/src/server.rs
@@ -64,8 +64,11 @@ pub(crate) async fn handle_logs(
     {
         let destination = destination.clone();
         let config = config.clone();
+        let runtime = tokio::runtime::Handle::current();
         let task_wait_ticket = config.new_waitgroup_ticket();
         rayon::spawn(move || {
+            let _guard = runtime.enter(); // so we can use tokio::spawn in this rayon task
+
             let body_text = match std::str::from_utf8(&body).context("invalid UTF-8 in body") {
                 Ok(body) => body,
                 Err(err) => {

--- a/src/server.rs
+++ b/src/server.rs
@@ -232,7 +232,7 @@ mod tests {
             .await;
 
         // wait for async tasks to finish
-        config.shutdown();
+        config.shutdown().await;
 
         let events: Vec<sentry::protocol::Event<'static>> = test_sentry_transport
             .fetch_and_clear_envelopes()


### PR DESCRIPTION
design decision: for the remaining time in Heroku, we'll continue using librato for metrics. 
Most log-based metrics (router, errors) are already parsed by librato, the same way that custom log-based metrics ( like the ones [generated with `thermondo_logging.librato`](https://github.com/thermondo/logging/blob/d521cc79618d4fda735622168bf4c437cd82a279/thermondo_logging/librato.py)) and dyno system metrics (memory etc) are already parsed. 

The only missing thing: our custom metrics for scaling. 

So this PR generates these, and sends them to librato via API. 

I'm relying on manual configuration where the `LIBRATO_USERNAME` and `LIBRATO_TOKEN` from the respective source applications have to be added to the mapping. 

After this PR I'll add another PR that _removes_ sentry metric generation. 


### testing
was tested (and can still be tested) using `log-reporter-test` & `tmail-test` 



<img width="1250" alt="grafik" src="https://github.com/user-attachments/assets/6b8b46cc-0925-4bed-8093-c7cd9a2008fe" />
