### PR TITLE
upgrade nom to v8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,12 +970,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,12 +1032,11 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.3"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
 dependencies = [
  "memchr",
- "minimal-lexical",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ axum-extra = { version = "0.10.0", features = ["typed-header"] }
 chrono = { version = "0.4.24", default-features = false, features = ["clock"] }
 crossbeam-utils = "0.8.15"
 hyper = "1.1.0"
-nom = "7.1.3"
+nom = "8.0.0"
 rayon = "1.7.0"
 reqwest = { version = "0.12.12", features = ["json"] }
 sentry = { version = "0.36.0", features = ["panic", "tower-http", "tracing"] }


### PR DESCRIPTION
https://github.com/rust-bakery/nom/blob/main/CHANGELOG.md#800-2025-01-25 


- remove usage of now deprecated `tuple` combinator 
- update from closure to tuple based API 