### PR TITLE
support sending scaling metrics to graphite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1172,9 +1172,11 @@ dependencies = [
  "rayon",
  "reqwest",
  "sentry",
+ "serde",
  "serde_json",
  "test-case",
  "tokio",
+ "toml",
  "tower",
  "tower-http",
  "tracing",
@@ -1996,6 +1998,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2313,6 +2324,45 @@ dependencies = [
  "pin-project-lite",
  "tokio",
 ]
+
+[[package]]
+name = "toml"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tower"
@@ -2901,6 +2951,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,14 @@ nom = "8.0.0"
 rayon = "1.7.0"
 reqwest = { version = "0.12.12", features = ["json"] }
 sentry = { version = "0.41.0", features = ["panic", "tower-http", "tracing"] }
+serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.135"
 tokio = { version = "1.28.0", features = [
   "rt-multi-thread",
   "macros",
   "signal",
 ] }
+toml = "0.9.2"
 tower = "0.5.0"
 tower-http = { version = "0.6.1", features = ["trace"] }
 tracing = "0.1.37"

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,8 +52,8 @@ impl DestinationSettings {
         })
     }
 
-    fn from_toml(line: &str) -> Result<Self> {
-        toml::from_str(line).context("failed to parse destination settings")
+    fn from_toml(value: &str) -> Result<Self> {
+        toml::from_str(value).context("failed to parse destination settings")
     }
 }
 

--- a/src/graphite.rs
+++ b/src/graphite.rs
@@ -1,0 +1,286 @@
+use anyhow::{Result, bail};
+use chrono::{DateTime, FixedOffset};
+use crossbeam_utils::sync::WaitGroup;
+use std::{
+    fmt::Display,
+    sync::Mutex,
+    time::{Duration, Instant},
+};
+use tracing::{debug, error};
+
+const FLUSH_INTERVAL: Duration = Duration::from_secs(60);
+const FLUSH_AFTER_QUEUE_LENGTH: usize = 100;
+#[cfg(not(test))]
+const DEFAULT_METRIC_ENDPOINT: &str = "https://www.hostedgraphite.com/api/v1/sink";
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct Measurement {
+    pub(crate) measure_time: DateTime<FixedOffset>,
+    pub(crate) value: f64,
+    pub(crate) name: String,
+}
+
+impl Display for Measurement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{} {} {}",
+            self.name,
+            self.value,
+            self.measure_time.timestamp()
+        )
+    }
+}
+
+#[derive(Debug)]
+struct State {
+    queue: Vec<Measurement>,
+    last_flush: Instant,
+    waitgroup: Option<WaitGroup>,
+}
+
+impl State {
+    fn reset(&mut self) {
+        self.queue.clear();
+        self.last_flush = Instant::now();
+    }
+}
+
+/// graphite client to send measurements to hosted graphite
+/// collects metrics in an internal queue and regularly send them to graphite
+/// in the background.
+/// Using the HTTP API:
+/// https://docs.hostedgraphite.com/sending-metrics/supported-protocols#http-post
+#[derive(Debug)]
+pub(crate) struct Client {
+    api_key: String,
+    state: Mutex<State>,
+    #[cfg(test)]
+    endpoint: String,
+}
+
+impl Client {
+    pub(crate) fn new(
+        api_key: impl Into<String>,
+        waitgroup: Option<WaitGroup>,
+        #[cfg(test)] endpoint: impl Into<String>,
+    ) -> anyhow::Result<Self> {
+        Ok(Self {
+            api_key: api_key.into(),
+            state: Mutex::new(State {
+                waitgroup,
+                queue: Vec::with_capacity(FLUSH_AFTER_QUEUE_LENGTH + 1),
+                last_flush: Instant::now(),
+            }),
+            #[cfg(test)]
+            endpoint: endpoint.into(),
+        })
+    }
+
+    /// add measurement to the local queue of measurements to be sent.
+    /// Will regularly flush the queue and send the measurements to graphite
+    /// in the background.
+    pub(crate) fn add_measurement(&self, measurement: Measurement) {
+        let mut state = self.state.lock().unwrap();
+        state.queue.push(measurement);
+
+        if !(state.last_flush.elapsed() > FLUSH_INTERVAL
+            || state.queue.len() > FLUSH_AFTER_QUEUE_LENGTH)
+        {
+            return;
+        }
+
+        debug!(?state.queue, "triggering background flushing to graphite");
+        tokio::spawn({
+            let queue = state.queue.clone();
+            let api_key = self.api_key.clone();
+            let waitgroup = state.waitgroup.clone();
+            #[cfg(test)]
+            let endpoint = self.endpoint.clone();
+            async move {
+                if let Err(err) = Client::send(
+                    &api_key,
+                    #[cfg(test)]
+                    &endpoint,
+                    #[cfg(not(test))]
+                    DEFAULT_METRIC_ENDPOINT,
+                    &queue,
+                )
+                .await
+                {
+                    error!(?err, api_key, ?queue, "error sending metrics to graphite");
+                }
+                drop(waitgroup);
+            }
+        });
+        state.reset();
+    }
+
+    /// shut down the graphite client, sending all pending events to graphite.
+    pub(crate) async fn shutdown(&self) -> Result<()> {
+        debug!("triggering shutdown of graphite client");
+        let queue = {
+            let mut state = self.state.lock().unwrap();
+
+            state.waitgroup.take();
+
+            let queue = state.queue.to_vec();
+            state.reset();
+            queue
+        };
+        if !queue.is_empty() {
+            Client::send(
+                &self.api_key,
+                #[cfg(test)]
+                &self.endpoint,
+                #[cfg(not(test))]
+                DEFAULT_METRIC_ENDPOINT,
+                &queue,
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
+    /// Actually send the measurements to graphite using TCP/IP with TLS.
+    #[tracing::instrument(skip(measurements))]
+    async fn send(
+        api_key: impl AsRef<str> + std::fmt::Debug,
+        endpoint: impl AsRef<str> + std::fmt::Debug,
+        measurements: &[Measurement],
+    ) -> Result<()> {
+        debug!("sending metrics to graphite");
+
+        let mut payload: Vec<u8> = Vec::with_capacity(64 * measurements.len());
+
+        for m in measurements {
+            payload.extend_from_slice(m.to_string().as_bytes());
+            payload.push(b'\n');
+        }
+
+        let response = reqwest::Client::new()
+            .post(endpoint.as_ref())
+            .basic_auth(api_key.as_ref(), None::<String>)
+            .body(payload)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            bail!(
+                "graphite returned an error code {}: {}",
+                response.status(),
+                response.text().await?
+            );
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_empty_shutdown() -> anyhow::Result<()> {
+        let client = Client::new("api-token", None, "invalid_endpoint")?;
+
+        // shutdown would fail if the client would try to send stuff to graphite
+        assert!(client.shutdown().await.is_ok());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_fails_with_queued_measurements() -> Result<()> {
+        let client = Client::new("api-token", None, "invalid_endpoint")?;
+
+        client.add_measurement(Measurement {
+            measure_time: chrono::Utc::now().into(),
+            value: 1.23,
+            name: "name".into(),
+        });
+
+        assert!(client.shutdown().await.is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_100_measures_trigger_flush() -> anyhow::Result<()> {
+        let mut server = mockito::Server::new_async().await;
+
+        let m = server
+            .mock("POST", "/")
+            .match_request(move |request| {
+                let body = request.body().unwrap();
+                let body = String::from_utf8_lossy(body);
+                let lines: Vec<_> = body.lines().collect();
+
+                assert_eq!(lines.len(), FLUSH_AFTER_QUEUE_LENGTH + 1);
+
+                true
+            })
+            .create();
+
+        let client = Client::new("api-token", None, server.url())?;
+
+        // one more measure than FLUSH_AFTER_QUEUE_LENGTH
+        for i in 0..(FLUSH_AFTER_QUEUE_LENGTH + 1) {
+            client.add_measurement(Measurement {
+                measure_time: chrono::Utc::now().into(),
+                value: i as f64,
+                name: format!("test-{i}"),
+            });
+        }
+
+        // wait a bit so the background task can finish
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        drop(client); // doesn't trigger graceful `.shutdown()`
+
+        m.assert_async().await;
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_shutdown_sends_queued_measurements() -> anyhow::Result<()> {
+        let timestamp = chrono::Utc::now();
+        let mut server = mockito::Server::new_async().await;
+
+        let m = server
+            .mock("POST", "/")
+            .match_request(move |request| {
+                let body = request.body().unwrap();
+                let body = String::from_utf8_lossy(body);
+                let lines: Vec<_> = body.lines().collect();
+
+                assert_eq!(
+                    lines,
+                    vec![
+                        format!("test 1.23 {}", timestamp.timestamp()),
+                        format!("another 3.21 {}", timestamp.timestamp())
+                    ]
+                );
+                true
+            })
+            .create();
+
+        let client = Client::new("api-token", None, server.url())?;
+
+        client.add_measurement(Measurement {
+            measure_time: timestamp.into(),
+            value: 1.23,
+            name: "test".into(),
+        });
+        client.add_measurement(Measurement {
+            measure_time: timestamp.into(),
+            value: 3.21,
+            name: "another".into(),
+        });
+
+        client.shutdown().await?;
+        m.assert_async().await;
+
+        Ok(())
+    }
+}

--- a/src/graphite.rs
+++ b/src/graphite.rs
@@ -142,7 +142,7 @@ impl Client {
         Ok(())
     }
 
-    /// Actually send the measurements to graphite using TCP/IP with TLS.
+    /// Actually send the measurements to graphite using their HTTP API
     #[tracing::instrument(skip(measurements))]
     async fn send(
         api_key: impl AsRef<str> + std::fmt::Debug,

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use tracing_subscriber::{EnvFilter, prelude::*};
 mod background;
 mod config;
 mod extractors;
+mod graphite;
 mod librato;
 mod log_parser;
 mod metrics;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,6 +1,25 @@
 use chrono::{DateTime, FixedOffset};
 
-use crate::{librato, log_parser::ScalingEvent};
+use crate::{graphite, librato, log_parser::ScalingEvent};
+
+/// generate graphite metrics from scaling events
+pub(crate) fn generate_graphite_scaling_metrics(
+    timestamp: &DateTime<FixedOffset>,
+    events: &[ScalingEvent<'_>],
+) -> Vec<graphite::Measurement> {
+    events
+        .iter()
+        .map(|event| {
+            // we we only need the low level detailed scaling event.
+            // If we don't care about the size, we would run a query like `web.dyno_count.*:sum`
+            graphite::Measurement {
+                measure_time: *timestamp,
+                value: event.count as f64,
+                name: format!("{}.dyno_count.{}", event.proc, event.size.to_lowercase()),
+            }
+        })
+        .collect()
+}
 
 /// generate librato metrics from scaling events
 pub(crate) fn generate_librato_scaling_metrics(
@@ -31,10 +50,32 @@ pub(crate) fn generate_librato_scaling_metrics(
 
 #[cfg(test)]
 mod tests {
-    use self::librato::{Kind, Measurement};
+    use self::{graphite, librato};
 
     use super::*;
     use chrono::Local;
+
+    #[test]
+    fn test_generate_graphite_scaling_metrics() {
+        let ts = Local::now().fixed_offset();
+        let result = generate_graphite_scaling_metrics(
+            &ts,
+            &[ScalingEvent {
+                proc: "web",
+                count: 99,
+                size: "huuuuge-2X",
+            }],
+        );
+
+        assert_eq!(
+            result,
+            vec![graphite::Measurement {
+                measure_time: ts,
+                name: "web.dyno_count.huuuuge-2x".into(),
+                value: 99.0,
+            },]
+        );
+    }
 
     #[test]
     fn test_generate_librato_scaling_metrics() {
@@ -51,16 +92,16 @@ mod tests {
         assert_eq!(
             result,
             vec![
-                Measurement {
+                librato::Measurement {
                     measure_time: ts,
-                    kind: Kind::Gauge,
+                    kind: librato::Kind::Gauge,
                     name: "dyno_count.huuuuge-2x".into(),
                     value: 99.0,
                     source: "web".into()
                 },
-                Measurement {
+                librato::Measurement {
                     measure_time: ts,
-                    kind: Kind::Gauge,
+                    kind: librato::Kind::Gauge,
                     name: "dyno_count".into(),
                     value: 99.0,
                     source: "web".into()

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -5,7 +5,7 @@ use crate::{
         parse_offer_extension_number, parse_offer_number, parse_project_reference,
         parse_scaling_event, parse_sfid,
     },
-    metrics::generate_librato_scaling_metrics,
+    metrics::{generate_graphite_scaling_metrics, generate_librato_scaling_metrics},
 };
 use anyhow::{Context as _, Result};
 use axum::http::uri::Uri;
@@ -169,24 +169,31 @@ pub(crate) fn process_logs(destination: Arc<Destination>, input: &str) -> Result
             }
         } else if matches!(log.kind, Kind::App)
             && log.source == "api"
-            && destination.librato_client.is_some()
+            && (destination.librato_client.is_some() || destination.graphite_client.is_some())
         {
             let Ok((_, (events, _user))) = parse_scaling_event(log.text) else {
                 continue;
             };
 
-            let Some(ref librato_client) = destination.librato_client else {
-                continue;
-            };
-
-            debug!("trying to report scaling metrics");
-
-            // store the scaling events in a cache so we can regularly re-send them.
+            // store the scaling events in a cache so we can regularly re-send them in a
+            // background task.
             let mut last_events = destination.last_scaling_events.lock().unwrap();
             *last_events = Some(events.iter().map(Into::into).collect());
 
-            for measurement in generate_librato_scaling_metrics(&log.timestamp, &events) {
-                librato_client.add_measurement(measurement);
+            if let Some(ref librato_client) = destination.librato_client {
+                debug!("trying to report scaling metrics to librato");
+
+                for measurement in generate_librato_scaling_metrics(&log.timestamp, &events) {
+                    librato_client.add_measurement(measurement);
+                }
+            }
+
+            if let Some(ref graphite_client) = destination.graphite_client {
+                debug!("trying to report scaling metrics to graphite");
+
+                for measurement in generate_graphite_scaling_metrics(&log.timestamp, &events) {
+                    graphite_client.add_measurement(measurement);
+                }
             }
         }
     }


### PR DESCRIPTION
As a first step implements graphite metric support as a parallel implementation, so we can switch over the config app by app, and even run it in parallel of the librato implementation so be able to test both side by side. 

Since adding more and more config vars feld odd in the old format, we now just put TOML tables into the destination config environment variables. Editing multi-line vars in Heroku is easy. 