### PR TITLE
fix new clippy errors

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -125,19 +125,19 @@ impl Config {
             // since we might have running background send-to-librato tasks.
             // the shutdown itself won't generate new tasks, so we're fine here.
 
-            if let Some(graphite_client) = &destination.graphite_client {
-                if let Err(err) = graphite_client.shutdown().await {
-                    error!(?err, "error shutting down graphite client ");
-                };
-            }
-            if let Some(librato_client) = &destination.librato_client {
-                if let Err(err) = librato_client.shutdown().await {
-                    error!(
-                        ?err,
-                        librato_client.username, "error shutting down librato client"
-                    );
-                };
-            }
+            if let Some(graphite_client) = &destination.graphite_client
+                && let Err(err) = graphite_client.shutdown().await
+            {
+                error!(?err, "error shutting down graphite client ");
+            };
+            if let Some(librato_client) = &destination.librato_client
+                && let Err(err) = librato_client.shutdown().await
+            {
+                error!(
+                    ?err,
+                    librato_client.username, "error shutting down librato client"
+                );
+            };
         }
 
         info!(?self.waitgroup, "waiting for pending background tasks");

--- a/src/log_parser.rs
+++ b/src/log_parser.rs
@@ -28,7 +28,7 @@ pub(crate) struct LogLine<'a> {
 pub(crate) type LogMap<'a> = BTreeMap<&'a str, &'a str>;
 
 #[instrument]
-pub(crate) fn parse_log_line(input: &str) -> IResult<&str, LogLine> {
+pub(crate) fn parse_log_line(input: &'_ str) -> IResult<&'_ str, LogLine<'_>> {
     map(
         (
             preceded(multispace0, digit1),
@@ -112,7 +112,9 @@ impl<'a> From<&ScalingEvent<'a>> for OwnedScalingEvent {
 /// parses heroku scaling events
 /// format like:
 ///     Scaled to web@4:Standard-1X worker@3:Standard-2X by user heroku.hirefire.api@thermondo.de
-pub(crate) fn parse_scaling_event(input: &str) -> IResult<&str, (Vec<ScalingEvent>, &str)> {
+pub(crate) fn parse_scaling_event(
+    input: &'_ str,
+) -> IResult<&'_ str, (Vec<ScalingEvent<'_>>, &'_ str)> {
     map(
         (
             preceded(multispace0, tag("Scaled to")),
@@ -128,7 +130,7 @@ pub(crate) fn parse_scaling_event(input: &str) -> IResult<&str, (Vec<ScalingEven
 /// parses single scaling element
 /// format like:
 ///     web@4:Standard-1X
-fn parse_single_scaling_event(input: &str) -> IResult<&str, ScalingEvent> {
+fn parse_single_scaling_event(input: &'_ str) -> IResult<&'_ str, ScalingEvent<'_>> {
     map(
         (
             take_till1(|c: char| c == '@'),
@@ -163,7 +165,7 @@ pub(crate) fn parse_dyno_error_code(input: &str) -> IResult<&str, (&str, &str)> 
     .parse(input)
 }
 
-pub(crate) fn parse_key_value_pairs(input: &str) -> IResult<&str, LogMap> {
+pub(crate) fn parse_key_value_pairs(input: &'_ str) -> IResult<&'_ str, LogMap<'_>> {
     map(
         many1(map(
             delimited(

--- a/src/reporter.rs
+++ b/src/reporter.rs
@@ -158,10 +158,10 @@ pub(crate) fn process_logs(destination: Arc<Destination>, input: &str) -> Result
                 continue;
             };
 
-            if *code == "H12" {
-                if let Some(msg) = generate_request_timeout_message(&log, &map) {
-                    send_to_sentry(destination.sentry_client.clone(), msg);
-                }
+            if *code == "H12"
+                && let Some(msg) = generate_request_timeout_message(&log, &map)
+            {
+                send_to_sentry(destination.sentry_client.clone(), msg);
             }
         } else if let Ok((_, (code, name))) = parse_dyno_error_code(log.text) {
             if let Some(msg) = generate_dyno_error_message(code, name, &log) {


### PR DESCRIPTION
coming because we always use the last stable rust release, so new rules might be added with after one. 

We theoretically could also freeze the rust version used, but typically I like it more this way
