### PR TITLE
fix(deps): resolve cargo audit advisories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2172,9 +2172,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary
- fix `RUSTSEC-2026-0104` affecting `rustls-webpki`
- update `rustls-webpki` from `0.103.12` to `0.103.13` in `Cargo.lock`
- `cargo audit` now passes with no remaining advisories